### PR TITLE
Fix repeated profile requests

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -48,10 +48,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (error || !data) {
       setUser(null);
     } else {
-      const email = session?.user?.email ?? data.email ?? '';
-      setUser({ ...data, email });
+      setUser({ ...data, email: data.email ?? '' });
     }
-  }, [session]);
+  }, []);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data }) => {


### PR DESCRIPTION
## Summary
- avoid `useAuth` effect re-triggering on session changes by removing dependency on `session`

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_688cdc9ec41883238066045358f5b6b5