### PR TITLE
Add agent analytics and appointment scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ supabase db push supabase/seed.sql
 If you already applied the initial seed you can run `supabase/update_v2.sql`
 to add the previous tables and policies. For the reviews feature introduced in
 this version, execute `supabase/update_v3.sql` as well.
+For the agent analytics and appointments features added in v4, run
+`supabase/update_v4.sql` after applying the earlier updates.
 
 5. **Deploy the Edge Function**
 

--- a/src/components/AppointmentForm.tsx
+++ b/src/components/AppointmentForm.tsx
@@ -1,0 +1,55 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useAddAppointment } from '../hooks/useAppointments';
+import { useAuth } from '../hooks/useAuth';
+
+const schema = z.object({
+  timeslot: z.string().min(1),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function AppointmentForm({ propertyId, agentId }: { propertyId: string; agentId: string }) {
+  const { user } = useAuth();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+  const add = useAddAppointment(propertyId, agentId);
+
+  async function onSubmit(data: FormData) {
+    await add.mutateAsync({ timeslot: new Date(data.timeslot) });
+    reset();
+  }
+
+  if (!user) return null;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2 max-w-md">
+      <div>
+        <label htmlFor="timeslot" className="block text-sm font-medium text-gray-700">
+          Select time
+        </label>
+        <input
+          type="datetime-local"
+          id="timeslot"
+          className="border rounded w-full p-2"
+          {...register('timeslot')}
+        />
+        {errors.timeslot && <p className="text-red-600 text-sm">Please choose a time</p>}
+      </div>
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+      >
+        {isSubmitting ? 'Requesting…' : 'Request viewing'}
+      </button>
+      {add.isError && <p className="text-red-600 text-sm">{(add.error as Error).message}</p>}
+      {add.isSuccess && <p className="text-green-700 text-sm">Request sent!</p>}
+    </form>
+  );
+}

--- a/src/hooks/useAppointments.tsx
+++ b/src/hooks/useAppointments.tsx
@@ -1,0 +1,49 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '../lib/supabaseClient';
+import { useAuth } from './useAuth';
+import type { Database } from '../types/supabase';
+
+type Appointment = Database['public']['Tables']['appointments']['Row'] & {
+  property?: { title: string | null };
+  user?: { full_name: string | null };
+};
+
+export function useAgentAppointments() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ['appointments', user?.id],
+    queryFn: async () => {
+      if (!user) return [] as Appointment[];
+      const { data, error } = await supabase
+        .from('appointments')
+        .select('*, property:property_id(title), user:user_id(full_name)')
+        .eq('agent_id', user.id)
+        .order('timeslot');
+      if (error) throw new Error(error.message);
+      return data ?? [];
+    },
+    enabled: !!user,
+  });
+}
+
+export function useAddAppointment(propertyId: string, agentId: string) {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  return useMutation(
+    async ({ timeslot }: { timeslot: Date }) => {
+      if (!user) throw new Error('Must be signed in');
+      const { error } = await supabase.from('appointments').insert({
+        property_id: propertyId,
+        agent_id: agentId,
+        user_id: user.id,
+        timeslot: timeslot.toISOString(),
+      });
+      if (error) throw new Error(error.message);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['appointments', agentId] });
+      },
+    },
+  );
+}

--- a/src/hooks/useListingStats.tsx
+++ b/src/hooks/useListingStats.tsx
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../lib/supabaseClient';
+import { useAuth } from './useAuth';
+import type { Database } from '../types/supabase';
+
+type Stat = Database['public']['Tables']['listing_stats']['Row'] & {
+  property?: { title: string | null };
+};
+
+export function useListingStats() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ['listing-stats', user?.id],
+    queryFn: async () => {
+      if (!user) return [] as Stat[];
+      const { data, error } = await supabase
+        .from('listing_stats')
+        .select('*, property:property_id!inner(title, agent_id)')
+        .eq('property.agent_id', user.id);
+      if (error) throw new Error(error.message);
+      return data ?? [];
+    },
+    enabled: !!user,
+  });
+}

--- a/src/hooks/useProperties.tsx
+++ b/src/hooks/useProperties.tsx
@@ -42,6 +42,7 @@ export function useProperties(filters: PropertyFilters) {
           `*, property_media!property_id(url, type, ord)`,
         )
         .order('created_at', { ascending: false });
+      query = query.eq('status', 'available');
 
       if (filters.postcode && filters.radiusMiles) {
         const coords = await lookupPostcode(filters.postcode);

--- a/src/pages/AgentDashboard/AgentDashboard.tsx
+++ b/src/pages/AgentDashboard/AgentDashboard.tsx
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabaseClient';
 import PropertyForm from './PropertyForm';
 import Messages from './Messages';
+import Appointments from './Appointments';
+import { useListingStats } from '../../hooks/useListingStats';
 import type { Database } from '../../types/supabase';
 
 type Property = Database['public']['Tables']['properties']['Row'];
@@ -17,6 +19,7 @@ type Property = Database['public']['Tables']['properties']['Row'];
 export default function AgentDashboard() {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const { data: stats } = useListingStats();
   const {
     data: properties,
     isLoading,
@@ -59,6 +62,9 @@ export default function AgentDashboard() {
         <Link to="messages" className="text-blue-600 underline">
           Messages
         </Link>
+        <Link to="appointments" className="text-blue-600 underline">
+          Appointments
+        </Link>
       </nav>
       <Routes>
         <Route
@@ -81,6 +87,13 @@ export default function AgentDashboard() {
                         £{p.price.toLocaleString()}{' '}
                         {p.listing_type === 'rent' ? '/mo' : ''}
                       </div>
+                      {stats && (
+                        <div className="text-xs text-gray-500 mb-2">
+                          views: {stats.find((s) => s.property_id === p.id)?.views ?? 0},
+                          enquiries: {stats.find((s) => s.property_id === p.id)?.enquiries ?? 0},
+                          favs: {stats.find((s) => s.property_id === p.id)?.favorites ?? 0}
+                        </div>
+                      )}
                       <button
                         onClick={() => navigate(`edit/${p.id}`)}
                         className="mt-auto text-blue-600 underline text-sm"
@@ -99,6 +112,7 @@ export default function AgentDashboard() {
         <Route path="new" element={<PropertyForm />} />
         <Route path="edit/:id" element={<PropertyForm />} />
         <Route path="messages" element={<Messages />} />
+        <Route path="appointments" element={<Appointments />} />
       </Routes>
     </div>
   );

--- a/src/pages/AgentDashboard/Appointments.tsx
+++ b/src/pages/AgentDashboard/Appointments.tsx
@@ -1,0 +1,34 @@
+import { useAgentAppointments } from '../../hooks/useAppointments';
+import { useAuth } from '../../hooks/useAuth';
+
+export default function Appointments() {
+  const { user } = useAuth();
+  const { data: appointments, isLoading, error } = useAgentAppointments();
+
+  if (!user) {
+    return <p>Please sign in as an agent to view appointments.</p>;
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Appointments</h2>
+      {isLoading && <p>Loading appointments…</p>}
+      {error && <p className="text-red-600">Error: {error.message}</p>}
+      {appointments && appointments.length > 0 ? (
+        <ul className="space-y-4">
+          {appointments.map((a) => (
+            <li key={a.id} className="border rounded p-4">
+              <div className="font-semibold">{a.property?.title ?? 'Unknown property'}</div>
+              <div className="text-sm text-gray-600">
+                {new Date(a.timeslot).toLocaleString()} –{' '}
+                {a.user?.full_name || 'Unknown'} (status: {a.status})
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No appointments.</p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/AgentDashboard/PropertyForm.tsx
+++ b/src/pages/AgentDashboard/PropertyForm.tsx
@@ -28,6 +28,7 @@ export default function PropertyForm() {
     bathrooms: 0,
     property_type: 'house',
     listing_type: 'sale',
+    status: 'available',
     address: '',
     city: '',
     postcode: '',
@@ -62,6 +63,7 @@ export default function PropertyForm() {
               bathrooms: data.bathrooms ?? 0,
               property_type: data.property_type ?? 'house',
               listing_type: data.listing_type ?? 'sale',
+              status: data.status ?? 'available',
               address: data.address ?? '',
               city: data.city ?? '',
               postcode: data.postcode ?? '',
@@ -234,6 +236,22 @@ export default function PropertyForm() {
             >
               <option value="sale">Sale</option>
               <option value="rent">Rent</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor="status">
+              Status
+            </label>
+            <select
+              id="status"
+              name="status"
+              value={form.status}
+              onChange={handleChange}
+              className="mt-1 block w-full border border-gray-300 rounded-md p-2 text-sm"
+            >
+              <option value="available">Available</option>
+              <option value="sold">Sold</option>
+              <option value="let">Let</option>
             </select>
           </div>
         </div>

--- a/src/pages/PropertyDetailPage.tsx
+++ b/src/pages/PropertyDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams, Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { supabase } from '../lib/supabaseClient';
 import { useAuth } from '../hooks/useAuth';
@@ -9,6 +9,7 @@ import PropertyList from '../components/PropertyList';
 import LineChart from '../components/LineChart';
 import ReviewList from '../components/ReviewList';
 import ReviewForm from '../components/ReviewForm';
+import AppointmentForm from '../components/AppointmentForm';
 import { useReviews } from '../hooks/useReviews';
 
 interface RouteParams {
@@ -81,6 +82,12 @@ export default function PropertyDetailPage() {
     reviews && reviews.length > 0
       ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length
       : null;
+
+  useEffect(() => {
+    if (property) {
+      supabase.rpc('increment_property_view', { p_id: property.id });
+    }
+  }, [property]);
 
   const [tab, setTab] = useState<'photos' | 'floor' | 'video'>('photos');
 
@@ -295,6 +302,7 @@ export default function PropertyDetailPage() {
           </p>
         )}
       </div>
+      <AppointmentForm propertyId={property.id} agentId={property.agent?.id ?? ''} />
       {/* Reviews */}
       <div>
         <h3 className="text-lg font-semibold mb-2">

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -74,6 +74,7 @@ export interface Database {
           tenure: string | null;
           amenities: string[] | null;
           has_photo: boolean;
+          status: string;
           agent_id: string | null;
           created_at: string | null;
           updated_at: string | null;
@@ -98,6 +99,7 @@ export interface Database {
           tenure?: string | null;
           amenities?: string[] | null;
           has_photo?: boolean;
+          status?: string;
           agent_id?: string | null;
           created_at?: string | null;
           updated_at?: string | null;
@@ -122,6 +124,7 @@ export interface Database {
           tenure?: string | null;
           amenities?: string[] | null;
           has_photo?: boolean;
+          status?: string;
           agent_id?: string | null;
           created_at?: string | null;
           updated_at?: string | null;
@@ -343,6 +346,83 @@ export interface Database {
             referencedRelation: 'profiles';
             referencedColumns: ['id'];
           },
+        ];
+      };
+      listing_stats: {
+        Row: {
+          property_id: string;
+          views: number;
+          enquiries: number;
+          favorites: number;
+        };
+        Insert: {
+          property_id: string;
+          views?: number;
+          enquiries?: number;
+          favorites?: number;
+        };
+        Update: {
+          property_id?: string;
+          views?: number;
+          enquiries?: number;
+          favorites?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'listing_stats_property_id_fkey';
+            columns: ['property_id'];
+            referencedRelation: 'properties';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
+      appointments: {
+        Row: {
+          id: string;
+          property_id: string | null;
+          user_id: string | null;
+          agent_id: string | null;
+          timeslot: string;
+          status: string;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          property_id: string;
+          user_id: string;
+          agent_id: string;
+          timeslot: string;
+          status?: string;
+          created_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          property_id?: string;
+          user_id?: string;
+          agent_id?: string;
+          timeslot?: string;
+          status?: string;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'appointments_property_id_fkey';
+            columns: ['property_id'];
+            referencedRelation: 'properties';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'appointments_user_id_fkey';
+            columns: ['user_id'];
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'appointments_agent_id_fkey';
+            columns: ['agent_id'];
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          }
         ];
       };
     };

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -50,6 +50,7 @@ create table if not exists public.properties (
   tenure text,
   amenities text[],
   has_photo boolean default false,
+  status text not null default 'available' check (status in ('available','sold','let')),
   agent_id uuid references public.profiles (id) on delete set null,
   created_at timestamp with time zone default now(),
   updated_at timestamp with time zone default now()
@@ -138,6 +139,31 @@ create table if not exists public.reviews (
   updated_at timestamp with time zone default now()
 );
 
+--
+-- Table: listing_stats
+--
+-- Stores aggregated view, enquiry and favourite counts per property.
+create table if not exists public.listing_stats (
+  property_id uuid references public.properties(id) on delete cascade primary key,
+  views integer not null default 0,
+  enquiries integer not null default 0,
+  favorites integer not null default 0
+);
+
+--
+-- Table: appointments
+--
+-- Viewing appointments requested by users. Agents confirm or cancel them.
+create table if not exists public.appointments (
+  id uuid primary key default uuid_generate_v4(),
+  property_id uuid references public.properties(id) on delete cascade,
+  user_id uuid references public.profiles(id) on delete cascade,
+  agent_id uuid references public.profiles(id) on delete cascade,
+  timeslot timestamp with time zone not null,
+  status text not null default 'pending' check (status in ('pending','confirmed','cancelled')),
+  created_at timestamp with time zone default now()
+);
+
 -- Enable Row Level Security for every table.  RLS must be enabled before policies can be
 -- applied.  By default, Supabase denies all access until explicit policies permit it.
 alter table public.profiles enable row level security;
@@ -148,6 +174,8 @@ alter table public.favorites enable row level security;
 alter table public.messages enable row level security;
 alter table public.saved_searches enable row level security;
 alter table public.reviews enable row level security;
+alter table public.listing_stats enable row level security;
+alter table public.appointments enable row level security;
 
 --
 -- RLS Policies for profiles
@@ -321,6 +349,29 @@ with check (user_id = auth.uid());
 create policy "Users can delete their reviews" on public.reviews
 for delete using (user_id = auth.uid());
 
+-- RLS Policies for listing_stats
+create policy "Agents can view stats for their listings" on public.listing_stats
+for select using (
+  exists(
+    select 1 from public.properties p
+    where p.id = listing_stats.property_id and p.agent_id = auth.uid()
+  )
+);
+
+-- RLS Policies for appointments
+create policy "Participants can view appointments" on public.appointments
+for select using (user_id = auth.uid() or agent_id = auth.uid());
+
+create policy "Users can request appointments" on public.appointments
+for insert with check (user_id = auth.uid());
+
+create policy "Agents can update appointment status" on public.appointments
+for update using (agent_id = auth.uid())
+with check (agent_id = auth.uid());
+
+create policy "Participants can delete appointments" on public.appointments
+for delete using (user_id = auth.uid() or agent_id = auth.uid());
+
 --
 -- Trigger to update properties.has_photo whenever images are added or removed.
 --
@@ -349,6 +400,79 @@ create trigger property_image_after_delete
 after delete on public.property_media
 for each row
 execute procedure public.update_property_has_photo();
+
+-- Trigger to insert listing_stats row when a property is created
+create or replace function public.init_listing_stats()
+returns trigger language plpgsql as $$
+begin
+  insert into public.listing_stats(property_id) values (new.id);
+  return new;
+end;
+$$;
+
+drop trigger if exists property_after_insert on public.properties;
+create trigger property_after_insert
+after insert on public.properties
+for each row execute procedure public.init_listing_stats();
+
+-- Trigger to increment enquiries when a message is sent
+create or replace function public.increment_enquiry()
+returns trigger language plpgsql as $$
+begin
+  if new.property_id is not null then
+    update public.listing_stats
+    set enquiries = enquiries + 1
+    where property_id = new.property_id;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists message_after_insert on public.messages;
+create trigger message_after_insert
+after insert on public.messages
+for each row execute procedure public.increment_enquiry();
+
+-- Triggers for favourites count
+create or replace function public.increment_favorite()
+returns trigger language plpgsql as $$
+begin
+  update public.listing_stats
+  set favorites = favorites + 1
+  where property_id = new.property_id;
+  return new;
+end;
+$$;
+
+create or replace function public.decrement_favorite()
+returns trigger language plpgsql as $$
+begin
+  update public.listing_stats
+  set favorites = greatest(favorites - 1, 0)
+  where property_id = old.property_id;
+  return old;
+end;
+$$;
+
+drop trigger if exists favorite_after_insert on public.favorites;
+create trigger favorite_after_insert
+after insert on public.favorites
+for each row execute procedure public.increment_favorite();
+
+drop trigger if exists favorite_after_delete on public.favorites;
+create trigger favorite_after_delete
+after delete on public.favorites
+for each row execute procedure public.decrement_favorite();
+
+-- Function to increment view count called manually
+create or replace function public.increment_property_view(p_id uuid)
+returns void language plpgsql as $$
+begin
+  update public.listing_stats
+  set views = views + 1
+  where property_id = p_id;
+end;
+$$;
 
 --
 -- Seed some data for development purposes.  This makes it easier to see the app
@@ -386,3 +510,18 @@ values
     5,
     'Loved staying here!',
     now() - interval '1 day');
+
+-- initialise stats for demo properties
+insert into public.listing_stats(property_id)
+select id from public.properties;
+
+-- demo appointment
+insert into public.appointments(id, property_id, user_id, agent_id, timeslot, status)
+values (
+  uuid_generate_v4(),
+  '11111111-2222-4333-8444-555555555555',
+  '00000000-0000-4000-8000-000000000002',
+  '00000000-0000-4000-8000-000000000001',
+  now() + interval '2 days',
+  'confirmed'
+);

--- a/supabase/update_v4.sql
+++ b/supabase/update_v4.sql
@@ -1,0 +1,106 @@
+-- Update script for v4 features (stats, appointments, listing status)
+-- Run this after update_v3.sql if upgrading an existing project
+
+alter table public.properties
+  add column if not exists status text not null default 'available'
+  check (status in ('available','sold','let'));
+
+create table if not exists public.listing_stats (
+  property_id uuid references public.properties(id) on delete cascade primary key,
+  views integer not null default 0,
+  enquiries integer not null default 0,
+  favorites integer not null default 0
+);
+
+create table if not exists public.appointments (
+  id uuid primary key default uuid_generate_v4(),
+  property_id uuid references public.properties(id) on delete cascade,
+  user_id uuid references public.profiles(id) on delete cascade,
+  agent_id uuid references public.profiles(id) on delete cascade,
+  timeslot timestamp with time zone not null,
+  status text not null default 'pending' check (status in ('pending','confirmed','cancelled')),
+  created_at timestamp with time zone default now()
+);
+
+alter table public.listing_stats enable row level security;
+alter table public.appointments enable row level security;
+
+create policy "Agents can view stats for their listings" on public.listing_stats
+for select using (
+  exists(select 1 from public.properties p where p.id = listing_stats.property_id and p.agent_id = auth.uid())
+);
+
+create policy "Participants can view appointments" on public.appointments
+for select using (user_id = auth.uid() or agent_id = auth.uid());
+create policy "Users can request appointments" on public.appointments
+for insert with check (user_id = auth.uid());
+create policy "Agents can update appointment status" on public.appointments
+for update using (agent_id = auth.uid()) with check (agent_id = auth.uid());
+create policy "Participants can delete appointments" on public.appointments
+for delete using (user_id = auth.uid() or agent_id = auth.uid());
+
+create or replace function public.init_listing_stats()
+returns trigger language plpgsql as $$
+begin
+  insert into public.listing_stats(property_id) values (new.id);
+  return new;
+end;
+$$;
+
+drop trigger if exists property_after_insert on public.properties;
+create trigger property_after_insert
+after insert on public.properties
+for each row execute procedure public.init_listing_stats();
+
+create or replace function public.increment_enquiry()
+returns trigger language plpgsql as $$
+begin
+  if new.property_id is not null then
+    update public.listing_stats set enquiries = enquiries + 1 where property_id = new.property_id;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists message_after_insert on public.messages;
+create trigger message_after_insert
+after insert on public.messages
+for each row execute procedure public.increment_enquiry();
+
+create or replace function public.increment_favorite()
+returns trigger language plpgsql as $$
+begin
+  update public.listing_stats set favorites = favorites + 1 where property_id = new.property_id;
+  return new;
+end;
+$$;
+
+create or replace function public.decrement_favorite()
+returns trigger language plpgsql as $$
+begin
+  update public.listing_stats set favorites = greatest(favorites - 1,0) where property_id = old.property_id;
+  return old;
+end;
+$$;
+
+drop trigger if exists favorite_after_insert on public.favorites;
+create trigger favorite_after_insert
+after insert on public.favorites
+for each row execute procedure public.increment_favorite();
+
+drop trigger if exists favorite_after_delete on public.favorites;
+create trigger favorite_after_delete
+after delete on public.favorites
+for each row execute procedure public.decrement_favorite();
+
+create or replace function public.increment_property_view(p_id uuid)
+returns void language plpgsql as $$
+begin
+  update public.listing_stats set views = views + 1 where property_id = p_id;
+end;
+$$;
+
+-- populate stats for existing properties
+insert into public.listing_stats(property_id)
+select id from public.properties
+where id not in (select property_id from public.listing_stats);


### PR DESCRIPTION
## Summary
- track listing performance with new `listing_stats` table
- add appointments table and calendar management
- allow agents to mark property status (available/sold/let)
- add hooks and components for appointments and stats
- update Agent dashboard to show analytics and appointments
- filter available properties in search
- seed and migration scripts for new tables

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688ce8c02a148323833a3a5d0212ed0d