### PR TITLE
Add agent appointment calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ If you already applied the initial seed you can run `supabase/update_v2.sql`
 to add the previous tables and policies. For the reviews feature introduced in
 this version, execute `supabase/update_v3.sql` as well.
 For the agent analytics and appointments features added in v4, run
-`supabase/update_v4.sql` after applying the earlier updates.
+`supabase/update_v4.sql` after applying the earlier updates. To load the
+sample data used by the new calendar view, execute `supabase/update_v5.sql`
+after running the previous updates.
 
 5. **Deploy the Edge Function**
 

--- a/src/components/AgentCalendar.tsx
+++ b/src/components/AgentCalendar.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import clsx from 'clsx';
+import type { Appointment } from '../hooks/useAppointments';
+
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function isSameMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+export default function AgentCalendar({
+  appointments,
+}: {
+  appointments: Appointment[];
+}) {
+  const [month, setMonth] = useState(new Date());
+
+  const monthStart = startOfMonth(month);
+  const startWeekDay = monthStart.getDay() === 0 ? 7 : monthStart.getDay();
+  const startDate = addDays(monthStart, -(startWeekDay - 1));
+
+  const days: Date[] = [];
+  for (let i = 0; i < 42; i++) {
+    days.push(addDays(startDate, i));
+  }
+
+  function nextMonth() {
+    setMonth(addDays(monthStart, 31));
+  }
+  function prevMonth() {
+    setMonth(addDays(monthStart, -1));
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <button onClick={prevMonth} className="px-2 py-1 border rounded">
+          Prev
+        </button>
+        <div className="font-semibold">
+          {month.toLocaleString(undefined, { month: 'long', year: 'numeric' })}
+        </div>
+        <button onClick={nextMonth} className="px-2 py-1 border rounded">
+          Next
+        </button>
+      </div>
+      <div className="grid grid-cols-7 text-center font-semibold mb-1">
+        <div>Mon</div>
+        <div>Tue</div>
+        <div>Wed</div>
+        <div>Thu</div>
+        <div>Fri</div>
+        <div>Sat</div>
+        <div>Sun</div>
+      </div>
+      <div className="grid grid-cols-7 border-t border-l">
+        {days.map((day, idx) => {
+          const items = appointments.filter((a) =>
+            isSameDay(new Date(a.timeslot), day),
+          );
+          return (
+            <div
+              key={idx}
+              className={clsx(
+                'border-b border-r h-24 p-1 text-xs',
+                !isSameMonth(day, month) && 'bg-gray-50 text-gray-400',
+              )}
+            >
+              <div className="font-semibold">{day.getDate()}</div>
+              {items.map((a) => (
+                <div key={a.id} className="bg-blue-100 rounded mt-0.5 px-1">
+                  {new Date(a.timeslot).toLocaleTimeString([], {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAppointments.tsx
+++ b/src/hooks/useAppointments.tsx
@@ -3,7 +3,7 @@ import { supabase } from '../lib/supabaseClient';
 import { useAuth } from './useAuth';
 import type { Database } from '../types/supabase';
 
-type Appointment = Database['public']['Tables']['appointments']['Row'] & {
+export type Appointment = Database['public']['Tables']['appointments']['Row'] & {
   property?: { title: string | null };
   user?: { full_name: string | null };
 };

--- a/src/pages/AgentDashboard/Appointments.tsx
+++ b/src/pages/AgentDashboard/Appointments.tsx
@@ -1,5 +1,6 @@
 import { useAgentAppointments } from '../../hooks/useAppointments';
 import { useAuth } from '../../hooks/useAuth';
+import AgentCalendar from '../../components/AgentCalendar';
 
 export default function Appointments() {
   const { user } = useAuth();
@@ -15,17 +16,7 @@ export default function Appointments() {
       {isLoading && <p>Loading appointments…</p>}
       {error && <p className="text-red-600">Error: {error.message}</p>}
       {appointments && appointments.length > 0 ? (
-        <ul className="space-y-4">
-          {appointments.map((a) => (
-            <li key={a.id} className="border rounded p-4">
-              <div className="font-semibold">{a.property?.title ?? 'Unknown property'}</div>
-              <div className="text-sm text-gray-600">
-                {new Date(a.timeslot).toLocaleString()} –{' '}
-                {a.user?.full_name || 'Unknown'} (status: {a.status})
-              </div>
-            </li>
-          ))}
-        </ul>
+        <AgentCalendar appointments={appointments} />
       ) : (
         <p>No appointments.</p>
       )}

--- a/supabase/update_v5.sql
+++ b/supabase/update_v5.sql
@@ -1,0 +1,13 @@
+-- Update script for calendar view enhancements
+-- Run this after update_v4.sql if upgrading an existing project
+
+-- Sample appointment data for testing the calendar
+insert into public.appointments(id, property_id, user_id, agent_id, timeslot, status)
+values (
+  uuid_generate_v4(),
+  '11111111-2222-4333-8444-555555555555',
+  '00000000-0000-4000-8000-000000000002',
+  '00000000-0000-4000-8000-000000000001',
+  now() + interval '14 days',
+  'pending'
+);


### PR DESCRIPTION
## Summary
- show appointments in a calendar view
- expose `Appointment` type for reuse
- document new update script
- provide sample update_v5.sql for calendar data

## Testing
- `npm run dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cf0ae1ec48323bd86a9a3bc967b1e