### PR TITLE
Add server-side caching for nearby amenities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project is a property listings portal inspired by popular real‑estate sit
 
 - **Browse and search properties** by location, price range, bedrooms, bathrooms, listing type and more.
 - **Property detail pages** with image galleries, descriptions, amenities, floor area, EPC rating and a contact form.
+- **Nearby schools and amenities** displayed on property pages using OpenStreetMap data cached via Supabase Edge Functions.
 - **Favourites**: authenticated users can save and remove favourite properties.
 - **Agent dashboard**: agents can create and edit their own listings, upload photos and respond to enquiries.
 - **Authentication** using Supabase’s email/password and magic‑link providers. A `profiles` table stores user roles (`user`, `agent`, `admin`).
@@ -51,7 +52,8 @@ this version, execute `supabase/update_v3.sql` as well.
 For the agent analytics and appointments features added in v4, run
 `supabase/update_v4.sql` after applying the earlier updates. To load the
 sample data used by the new calendar view, execute `supabase/update_v5.sql`
-after running the previous updates.
+after running the previous updates. To enable caching for nearby schools and
+amenities, apply `supabase/update_v6.sql` next.
 
 5. **Deploy the Edge Function**
 

--- a/supabase/functions/nearby/index.ts
+++ b/supabase/functions/nearby/index.ts
@@ -1,8 +1,32 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.43.1';
 
 serve(async (req) => {
   const { lat, lon } = await req.json();
-  const query = `[out:json];(node(around:1000,${lat},${lon})[amenity=school];);out;`;
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  );
+
+  const latKey = Math.round(lat * 1000) / 1000;
+  const lonKey = Math.round(lon * 1000) / 1000;
+
+  const { data: cached } = await supabase
+    .from('nearby_cache')
+    .select('results')
+    .eq('lat', latKey)
+    .eq('lon', lonKey)
+    .maybeSingle();
+
+  if (cached) {
+    return new Response(JSON.stringify({ results: cached.results }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const query =
+    `[out:json];(node(around:1000,${lat},${lon})[amenity~"(school|hospital|pharmacy|restaurant|cafe|pub|bar|supermarket|bank)"];);out;`;
   const res = await fetch('https://overpass-api.de/api/interpreter', {
     method: 'POST',
     body: query,
@@ -11,6 +35,14 @@ serve(async (req) => {
   const results = data.elements
     .map((el) => el.tags?.name)
     .filter((n): n is string => Boolean(n));
+
+  await supabase.from('nearby_cache').upsert({
+    lat: latKey,
+    lon: lonKey,
+    results,
+    created_at: new Date().toISOString(),
+  });
+
   return new Response(JSON.stringify({ results }), {
     headers: { 'Content-Type': 'application/json' },
   });

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -164,6 +164,18 @@ create table if not exists public.appointments (
   created_at timestamp with time zone default now()
 );
 
+--
+-- Table: nearby_cache
+--
+-- Caches results from the Overpass API for nearby schools and amenities.
+create table if not exists public.nearby_cache (
+  lat numeric not null,
+  lon numeric not null,
+  results text[] not null,
+  created_at timestamp with time zone default now(),
+  primary key (lat, lon)
+);
+
 -- Enable Row Level Security for every table.  RLS must be enabled before policies can be
 -- applied.  By default, Supabase denies all access until explicit policies permit it.
 alter table public.profiles enable row level security;

--- a/supabase/update_v6.sql
+++ b/supabase/update_v6.sql
@@ -1,0 +1,10 @@
+-- Update script for nearby caching
+-- Run this after update_v5.sql if upgrading an existing project
+
+create table if not exists public.nearby_cache (
+  lat numeric not null,
+  lon numeric not null,
+  results text[] not null,
+  created_at timestamp with time zone default now(),
+  primary key (lat, lon)
+);


### PR DESCRIPTION
## Summary
- add `nearby_cache` table in schema and new `update_v6.sql`
- cache Overpass API lookups in `supabase/functions/nearby`
- document new feature and migration steps

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cf68d700c83239497f77016e31b25