### PR TITLE
Add favorite lists and comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ For the agent analytics and appointments features added in v4, run
 sample data used by the new calendar view, execute `supabase/update_v5.sql`
 after running the previous updates. To enable caching for nearby schools and
 amenities, apply `supabase/update_v6.sql` next.
+For favourite lists and comparison support added in v7, run
+`supabase/update_v7.sql` after applying the earlier updates.
 
 5. **Deploy the Edge Function**
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import AgentDashboard from './pages/AgentDashboard/AgentDashboard';
 import FavoritesPage from './pages/FavoritesPage';
+import FavoriteListsPage from './pages/FavoriteListsPage';
+import ComparePage from './pages/ComparePage';
 
 /**
  * Root component for the application.  It defines the top level layout
@@ -24,6 +26,8 @@ export default function App() {
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/agent/*" element={<AgentDashboard />} />
           <Route path="/favorites" element={<FavoritesPage />} />
+          <Route path="/lists" element={<FavoriteListsPage />} />
+          <Route path="/compare" element={<ComparePage />} />
         </Routes>
       </main>
     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -34,6 +34,22 @@ export default function Navbar() {
               Favourites
             </Link>
           )}
+          {user && (
+            <Link
+              to="/lists"
+              className="text-gray-700 hover:text-blue-600 hidden sm:inline"
+            >
+              Lists
+            </Link>
+          )}
+          {user && (
+            <Link
+              to="/compare"
+              className="text-gray-700 hover:text-blue-600 hidden sm:inline"
+            >
+              Compare
+            </Link>
+          )}
           {user?.role === 'agent' && (
             <Link
               to="/agent"

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useFavorites, useToggleFavorite } from '../hooks/useFavorites';
 import { useAuth } from '../hooks/useAuth';
+import { useComparison } from '../hooks/useComparison';
 import type { Database } from '../types/supabase';
 
 type Property = Database['public']['Tables']['properties']['Row'] & {
@@ -21,6 +22,8 @@ export default function PropertyCard({ property }: Props) {
   const { data: favourites } = useFavorites();
   const toggleFavourite = useToggleFavorite();
   const isFavourited = favourites?.includes(property.id);
+  const { selected, toggle: toggleCompare } = useComparison();
+  const inCompare = selected.includes(property.id);
 
   const firstImage =
     property.property_media?.find((m) => m.type === 'photo') || null;
@@ -29,6 +32,12 @@ export default function PropertyCard({ property }: Props) {
     e.preventDefault();
     if (!user) return;
     await toggleFavourite.mutateAsync(property.id);
+  }
+
+  function handleCompare(e: React.MouseEvent) {
+    e.preventDefault();
+    if (!user) return;
+    toggleCompare(property.id);
   }
 
   return (
@@ -64,21 +73,26 @@ export default function PropertyCard({ property }: Props) {
             </span>
           </div>
           {user && (
-            <button
-              onClick={handleToggle}
-              className="p-2 rounded-full hover:bg-gray-100"
-              title={isFavourited ? 'Remove from favourites' : 'Save to favourites'}
-            >
-              {isFavourited ? (
-                <span role="img" aria-label="favourited">
-                  ❤️
-                </span>
-              ) : (
-                <span role="img" aria-label="not favourited">
-                  🤍
-                </span>
-              )}
-            </button>
+            <div className="flex gap-2">
+              <button
+                onClick={handleToggle}
+                className="p-2 rounded-full hover:bg-gray-100"
+                title={isFavourited ? 'Remove from favourites' : 'Save to favourites'}
+              >
+                {isFavourited ? (
+                  <span role="img" aria-label="favourited">❤️</span>
+                ) : (
+                  <span role="img" aria-label="not favourited">🤍</span>
+                )}
+              </button>
+              <button
+                onClick={handleCompare}
+                className="p-2 rounded-full hover:bg-gray-100"
+                title={inCompare ? 'Remove from comparison' : 'Add to comparison'}
+              >
+                {inCompare ? '✓' : '≣'}
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/src/hooks/useComparison.tsx
+++ b/src/hooks/useComparison.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+interface ComparisonContextType {
+  selected: string[];
+  toggle: (id: string) => void;
+  clear: () => void;
+}
+
+const ComparisonContext = createContext<ComparisonContextType | undefined>(undefined);
+
+export function ComparisonProvider({ children }: { children: ReactNode }) {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      if (prev.includes(id)) {
+        return prev.filter((p) => p !== id);
+      }
+      if (prev.length >= 3) {
+        return [...prev.slice(1), id];
+      }
+      return [...prev, id];
+    });
+  };
+
+  const clear = () => setSelected([]);
+
+  return (
+    <ComparisonContext.Provider value={{ selected, toggle, clear }}>
+      {children}
+    </ComparisonContext.Provider>
+  );
+}
+
+export function useComparison() {
+  const ctx = useContext(ComparisonContext);
+  if (!ctx) throw new Error('useComparison must be used within ComparisonProvider');
+  return ctx;
+}

--- a/src/hooks/useFavoriteLists.tsx
+++ b/src/hooks/useFavoriteLists.tsx
@@ -1,0 +1,78 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '../lib/supabaseClient';
+import { useAuth } from './useAuth';
+import type { Database } from '../types/db';
+
+export type FavoriteList = Database['public']['Tables']['favorite_lists']['Row'];
+
+export function useFavoriteLists() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ['favorite_lists', user?.id],
+    queryFn: async () => {
+      if (!user) return [] as FavoriteList[];
+      const { data, error } = await supabase
+        .from('favorite_lists')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('created_at');
+      if (error) throw new Error(error.message);
+      return data ?? [];
+    },
+    enabled: !!user,
+  });
+}
+
+export function useCreateFavoriteList() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  return useMutation(
+    async (name: string) => {
+      if (!user) throw new Error('Must be signed in');
+      const { error } = await supabase
+        .from('favorite_lists')
+        .insert({ user_id: user.id, name });
+      if (error) throw new Error(error.message);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['favorite_lists'] });
+      },
+    },
+  );
+}
+
+export function useAddPropertyToList() {
+  const queryClient = useQueryClient();
+  return useMutation(
+    async ({ listId, propertyId }: { listId: string; propertyId: string }) => {
+      const { error } = await supabase
+        .from('favorite_list_items')
+        .insert({ list_id: listId, property_id: propertyId });
+      if (error) throw new Error(error.message);
+    },
+    {
+      onSuccess: (_data, variables) => {
+        queryClient.invalidateQueries({
+          queryKey: ['list_items', variables.listId],
+        });
+      },
+    },
+  );
+}
+
+export function useListItems(listId: string | null) {
+  return useQuery({
+    queryKey: ['list_items', listId],
+    queryFn: async () => {
+      if (!listId) return [] as Database['public']['Tables']['properties']['Row'][];
+      const { data, error } = await supabase
+        .from('favorite_list_items')
+        .select('property:properties(*)')
+        .eq('list_id', listId);
+      if (error) throw new Error(error.message);
+      return data?.map((d) => d.property) ?? [];
+    },
+    enabled: !!listId,
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import { AuthProvider } from './hooks/useAuth';
+import { ComparisonProvider } from './hooks/useComparison';
 import './index.css';
 
 // Create a single React Query client for the entire app.  This allows components
@@ -16,7 +17,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <AuthProvider>
-          <App />
+          <ComparisonProvider>
+            <App />
+          </ComparisonProvider>
         </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>

--- a/src/pages/ComparePage.tsx
+++ b/src/pages/ComparePage.tsx
@@ -1,0 +1,75 @@
+import { useComparison } from '../hooks/useComparison';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../lib/supabaseClient';
+import type { Database } from '../types/db';
+
+type PropertyRow = Database['public']['Tables']['properties']['Row'];
+
+export default function ComparePage() {
+  const { selected, clear } = useComparison();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['compare', selected],
+    queryFn: async () => {
+      if (selected.length === 0) return [] as PropertyRow[];
+      const { data, error } = await supabase
+        .from('properties')
+        .select('*')
+        .in('id', selected);
+      if (error) throw new Error(error.message);
+      return data ?? [];
+    },
+    enabled: selected.length > 0,
+  });
+
+  if (selected.length === 0) {
+    return <p className="p-4">No properties selected for comparison.</p>;
+  }
+  if (isLoading) return <p className="p-4">Loading…</p>;
+  if (error) return <p className="p-4 text-red-600">Error: {(error as Error).message}</p>;
+
+  const rows: { label: string; get: (p: PropertyRow) => React.ReactNode }[] = [
+    { label: 'Price', get: (p) => `£${p.price.toLocaleString()}` },
+    { label: 'Bedrooms', get: (p) => p.bedrooms },
+    { label: 'Bathrooms', get: (p) => p.bathrooms },
+    { label: 'Type', get: (p) => p.property_type },
+    { label: 'Listing', get: (p) => p.listing_type },
+  ];
+
+  return (
+    <div className="max-w-7xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">
+        Comparison
+        <button className="ml-4 text-sm text-blue-600 underline" onClick={clear}>
+          Clear
+        </button>
+      </h1>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border text-sm">
+          <thead>
+            <tr>
+              <th className="p-2 border" />
+              {data!.map((p) => (
+                <th key={p.id} className="p-2 border">
+                  {p.title}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.label}>
+                <th className="p-2 border text-left font-medium">{row.label}</th>
+                {data!.map((p) => (
+                  <td key={p.id} className="p-2 border text-center">
+                    {row.get(p)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/FavoriteListsPage.tsx
+++ b/src/pages/FavoriteListsPage.tsx
@@ -1,0 +1,50 @@
+import { useFavoriteLists, useListItems, useCreateFavoriteList } from '../hooks/useFavoriteLists';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useAuth } from '../hooks/useAuth';
+import PropertyList from '../components/PropertyList';
+
+const schema = z.object({ name: z.string().min(1) });
+type FormData = z.infer<typeof schema>;
+
+export default function FavoriteListsPage() {
+  const { user } = useAuth();
+  const { data: lists, isLoading, error } = useFavoriteLists();
+  const createList = useCreateFavoriteList();
+  const { register, handleSubmit, reset, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  async function onSubmit(data: FormData) {
+    await createList.mutateAsync(data.name);
+    reset();
+  }
+
+  if (!user) return <p className="p-4">Please sign in to manage lists.</p>;
+  if (isLoading) return <p className="p-4">Loading…</p>;
+  if (error) return <p className="p-4 text-red-600">Error: {(error as Error).message}</p>;
+
+  return (
+    <div className="max-w-5xl mx-auto p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Your lists</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="flex gap-2 max-w-md">
+        <input className="border p-2 flex-1" placeholder="List name" {...register('name')} />
+        <button type="submit" className="bg-blue-600 text-white px-3 py-2 rounded">Add</button>
+      </form>
+      {errors.name && <p className="text-red-600 text-sm">Name is required</p>}
+      {lists && lists.length === 0 && <p>No lists yet.</p>}
+      {lists?.map((list) => (
+        <ListSection key={list.id} listId={list.id} name={list.name} />
+      ))}
+    </div>
+  );
+}
+
+function ListSection({ listId, name }: { listId: string; name: string }) {
+  const { data: properties } = useListItems(listId);
+  return (
+    <div className="border p-4 rounded">
+      <h2 className="font-semibold mb-2">{name}</h2>
+      <PropertyList properties={properties || []} />
+    </div>
+  );
+}

--- a/src/pages/PropertyDetailPage.tsx
+++ b/src/pages/PropertyDetailPage.tsx
@@ -11,6 +11,8 @@ import ReviewList from '../components/ReviewList';
 import ReviewForm from '../components/ReviewForm';
 import AppointmentForm from '../components/AppointmentForm';
 import { useReviews } from '../hooks/useReviews';
+import { useFavoriteLists, useAddPropertyToList } from '../hooks/useFavoriteLists';
+import { useComparison } from '../hooks/useComparison';
 
 interface RouteParams {
   id: string;
@@ -90,6 +92,10 @@ export default function PropertyDetailPage() {
   }, [property]);
 
   const [tab, setTab] = useState<'photos' | 'floor' | 'video'>('photos');
+
+  const { data: lists } = useFavoriteLists();
+  const addToList = useAddPropertyToList();
+  const { toggle: toggleCompare, selected } = useComparison();
 
   // Mutation for sending a message to the agent.
   const sendMessage = useMutation(async (content: string) => {
@@ -222,6 +228,37 @@ export default function PropertyDetailPage() {
         )}
         {property.tenure && (
           <div className="text-gray-700">Tenure: {property.tenure}</div>
+        )}
+        {user && lists && (
+          <div>
+            <label htmlFor="favlist" className="mr-2 text-sm">Save to list:</label>
+            <select
+              id="favlist"
+              className="border p-1"
+              onChange={(e) => {
+                const val = e.target.value;
+                if (val) {
+                  addToList.mutate({ listId: val, propertyId: property.id });
+                  e.currentTarget.selectedIndex = 0;
+                }
+              }}
+            >
+              <option value="">Select</option>
+              {lists?.map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+        {user && (
+          <button
+            onClick={() => toggleCompare(property.id)}
+            className="mt-2 px-3 py-1 border rounded"
+          >
+            {selected.includes(property.id) ? 'Remove from compare' : 'Compare'}
+          </button>
         )}
         {property.amenities && property.amenities.length > 0 && (
           <div className="flex flex-wrap gap-2">

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,0 +1,1 @@
+export * from './supabase';

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -231,6 +231,65 @@ export interface Database {
           },
         ];
       };
+      favorite_lists: {
+        Row: {
+          id: string;
+          user_id: string | null;
+          name: string;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          created_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          name?: string;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'favorite_lists_user_id_fkey';
+            columns: ['user_id'];
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
+      favorite_list_items: {
+        Row: {
+          list_id: string;
+          property_id: string;
+          created_at: string | null;
+        };
+        Insert: {
+          list_id: string;
+          property_id: string;
+          created_at?: string | null;
+        };
+        Update: {
+          list_id?: string;
+          property_id?: string;
+          created_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'favorite_list_items_list_id_fkey';
+            columns: ['list_id'];
+            referencedRelation: 'favorite_lists';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'favorite_list_items_property_id_fkey';
+            columns: ['property_id'];
+            referencedRelation: 'properties';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       messages: {
         Row: {
           id: string;

--- a/supabase/update_v7.sql
+++ b/supabase/update_v7.sql
@@ -1,0 +1,52 @@
+-- Update script for favorite lists and comparison features
+-- Run this after update_v6.sql if upgrading an existing project
+
+create table if not exists public.favorite_lists (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references public.profiles (id) on delete cascade,
+  name text not null,
+  created_at timestamp with time zone default now()
+);
+
+create table if not exists public.favorite_list_items (
+  list_id uuid references public.favorite_lists(id) on delete cascade,
+  property_id uuid references public.properties(id) on delete cascade,
+  created_at timestamp with time zone default now(),
+  primary key (list_id, property_id)
+);
+
+alter table public.favorite_lists enable row level security;
+alter table public.favorite_list_items enable row level security;
+
+create policy "Users can view their favorite lists" on public.favorite_lists
+  for select using (user_id = auth.uid());
+
+create policy "Users can create favorite lists" on public.favorite_lists
+  for insert with check (user_id = auth.uid());
+
+create policy "Users can delete favorite lists" on public.favorite_lists
+  for delete using (user_id = auth.uid());
+
+create policy "Users can view list items" on public.favorite_list_items
+  for select using (
+    exists (
+      select 1 from public.favorite_lists fl
+      where fl.id = favorite_list_items.list_id and fl.user_id = auth.uid()
+    )
+  );
+
+create policy "Users can add list items" on public.favorite_list_items
+  for insert with check (
+    exists (
+      select 1 from public.favorite_lists fl
+      where fl.id = favorite_list_items.list_id and fl.user_id = auth.uid()
+    )
+  );
+
+create policy "Users can remove list items" on public.favorite_list_items
+  for delete using (
+    exists (
+      select 1 from public.favorite_lists fl
+      where fl.id = favorite_list_items.list_id and fl.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- add new tables for `favorite_lists` and `favorite_list_items`
- support creating favorite lists and assigning properties
- implement comparison view with up to three properties
- expose comparison and list management in the UI
- update TypeScript types and seed data
- document new update script

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688d0465e1948323a1585fafb1c96514