### PR TITLE
Add Leaflet map view

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project is a property listings portal inspired by popular real‑estate sit
 - **Authentication** using Supabase’s email/password and magic‑link providers. A `profiles` table stores user roles (`user`, `agent`, `admin`).
 - **Messaging**: users can send messages to agents about a property; agents can read and reply.
 - **Row Level Security** policies are implemented to ensure users only read and modify the data they are authorised to access.
+- **Interactive map of search results** using Leaflet with marker clustering.
 
 ## Getting started
 
@@ -23,6 +24,8 @@ This project is a property listings portal inspired by popular real‑estate sit
    ```
 
 2. **Install dependencies**
+
+   The project uses Leaflet for the map view so be sure all npm packages are installed:
 
    ```bash
    npm install

--- a/package.json
+++ b/package.json
@@ -8,38 +8,41 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --max-warnings=0",
-    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,html}\""
-    ,"test:e2e": "playwright test"
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,html}\"",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
-    "react": "^18.3.0",
-    "react-dom": "^18.3.0",
-    "react-router-dom": "^6.22.1",
+    "@hookform/resolvers": "^3.3.2",
     "@supabase/supabase-js": "^2.43.1",
     "@tanstack/react-query": "^4.30.0",
-    "react-hook-form": "^7.51.3",
-    "@hookform/resolvers": "^3.3.2",
-    "zod": "^3.22.4",
     "clsx": "^2.1.0",
-    "tailwindcss": "^3.4.4"
+    "leaflet": "^1.9.4",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "react-hook-form": "^7.51.3",
+    "react-leaflet": "^4.2.1",
+    "react-leaflet-cluster": "^2.1.0",
+    "react-router-dom": "^6.22.1",
+    "tailwindcss": "^3.4.4",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.39.1",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
     "@vitejs/plugin-react": "^4.2.0",
     "autoprefixer": "^10.4.15",
-    "postcss": "^8.4.31",
-    "typescript": "^5.3.3",
-    "vite": "^4.4.9",
+    "cypress": "^12.17.3",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "@typescript-eslint/parser": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^6.7.0",
-    "prettier": "^3.0.0",
-    "cypress": "^12.17.3",
     "playwright": "^1.39.1",
-    "@playwright/test": "^1.39.1"
+    "postcss": "^8.4.31",
+    "prettier": "^3.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^4.4.9"
   }
 }

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import MarkerClusterGroup from 'react-leaflet-cluster';
+import { Link, useNavigate } from 'react-router-dom';
+import type { Database } from '../types/db';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+// Fix default icon paths in Leaflet when bundling with Vite
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: markerIcon2x,
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+});
+
+type Property = Database['public']['Tables']['properties']['Row'] & {
+  property_media?: { url: string; type: string; ord: number | null }[];
+};
+
+interface Props {
+  properties: Property[];
+}
+
+export default function PropertyMap({ properties }: Props) {
+  const navigate = useNavigate();
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const center = properties.length
+    ? [properties[0].latitude ?? 51.505, properties[0].longitude ?? -0.09]
+    : [51.505, -0.09];
+
+  return (
+    <MapContainer
+      center={center as L.LatLngExpression}
+      zoom={13}
+      className="h-96 w-full z-0"
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <MarkerClusterGroup>
+        {properties.map((p) => {
+          if (p.latitude == null || p.longitude == null) return null;
+          const first = p.property_media?.find((m) => m.type === 'photo');
+          return (
+            <Marker
+              key={p.id}
+              position={[p.latitude, p.longitude] as L.LatLngExpression}
+              eventHandlers={{
+                click: () => {
+                  if (activeId === p.id) {
+                    navigate(`/properties/${p.id}`);
+                  } else {
+                    setActiveId(p.id);
+                  }
+                },
+              }}
+            >
+              <Popup>
+                <div className="text-center">
+                  {first && (
+                    <img src={first.url} alt="thumbnail" className="w-32 h-20 object-cover mb-1" />
+                  )}
+                  <Link to={`/properties/${p.id}`} className="text-blue-600 underline">
+                    {p.title}
+                  </Link>
+                </div>
+              </Popup>
+            </Marker>
+          );
+        })}
+      </MarkerClusterGroup>
+    </MapContainer>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import PropertyList from '../components/PropertyList';
 import PropertyFilter from '../components/PropertyFilter';
 import { useProperties } from '../hooks/useProperties';
 import type { PropertyFilters } from '../hooks/useProperties';
 import { useSaveSearch } from '../hooks/useSavedSearches';
 import { useAuth } from '../hooks/useAuth';
+
+const PropertyMap = lazy(() => import('../components/PropertyMap'));
 
 /**
  * Landing page for browsing and searching properties.  Maintains the current
@@ -35,7 +37,12 @@ export default function HomePage() {
           <p className="p-4 text-red-600">Error: {error.message}</p>
         )}
         {!isLoading && !error && properties && (
-          <PropertyList properties={properties} />
+          <>
+            <PropertyList properties={properties} />
+            <Suspense fallback={<p className="p-4">Loading map…</p>}>
+              <PropertyMap properties={properties} />
+            </Suspense>
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- integrate `leaflet` and `react-leaflet` for displaying search results on a map
- lazy-load `PropertyMap` in `HomePage` to keep the bundle light
- add map dependencies
- document map feature and updated setup instructions in `README`

## Testing
- `npm run lint`
- `npm run build` *(fails: Rollup could not resolve `react-leaflet` because dependencies cannot be installed)*
- `npm run test:e2e` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d08e2bd54832395da48cae45df29d