### PR TITLE
Add saved searches page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project is a property listings portal inspired by popular real‑estate sit
 - **Property detail pages** with image galleries, descriptions, amenities, floor area, EPC rating and a contact form.
 - **Nearby schools and amenities** displayed on property pages using OpenStreetMap data cached via Supabase Edge Functions.
 - **Favourites**: authenticated users can save and remove favourite properties.
+- **Saved searches**: logged in users can store their search criteria and rerun them later from the Saved Searches page.
 - **Agent dashboard**: agents can create and edit their own listings, upload photos and respond to enquiries.
 - **Authentication** using Supabase’s email/password and magic‑link providers. A `profiles` table stores user roles (`user`, `agent`, `admin`).
 - **Messaging**: users can send messages to agents about a property; agents can read and reply.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import AgentDashboard from './pages/AgentDashboard/AgentDashboard';
 import FavoritesPage from './pages/FavoritesPage';
 import FavoriteListsPage from './pages/FavoriteListsPage';
 import ComparePage from './pages/ComparePage';
+import SavedSearchesPage from './pages/SavedSearchesPage';
 
 /**
  * Root component for the application.  It defines the top level layout
@@ -27,6 +28,7 @@ export default function App() {
           <Route path="/agent/*" element={<AgentDashboard />} />
           <Route path="/favorites" element={<FavoritesPage />} />
           <Route path="/lists" element={<FavoriteListsPage />} />
+          <Route path="/saved-searches" element={<SavedSearchesPage />} />
           <Route path="/compare" element={<ComparePage />} />
         </Routes>
       </main>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -23,7 +23,10 @@ export default function Navbar() {
           <Link to="/" className="text-xl font-semibold text-blue-600">
             Property Portal
           </Link>
-          <Link to="/" className="text-gray-700 hover:text-blue-600 hidden sm:inline">
+          <Link
+            to="/"
+            className="text-gray-700 hover:text-blue-600 hidden sm:inline"
+          >
             Browse
           </Link>
           {user && (
@@ -40,6 +43,14 @@ export default function Navbar() {
               className="text-gray-700 hover:text-blue-600 hidden sm:inline"
             >
               Lists
+            </Link>
+          )}
+          {user && (
+            <Link
+              to="/saved-searches"
+              className="text-gray-700 hover:text-blue-600 hidden sm:inline"
+            >
+              Saved Searches
             </Link>
           )}
           {user && (

--- a/src/hooks/useSavedSearches.tsx
+++ b/src/hooks/useSavedSearches.tsx
@@ -7,12 +7,12 @@ export function useSavedSearches() {
   const { user } = useAuth();
   return useQuery({
     queryKey: ['saved_searches', user?.id],
-      queryFn: async () => {
-        if (!user) return [] as PropertyFilters[];
-        const { data, error } = await supabase
-          .from('saved_searches')
-          .select('*')
-          .eq('user_id', user.id);
+    queryFn: async () => {
+      if (!user) return [] as PropertyFilters[];
+      const { data, error } = await supabase
+        .from('saved_searches')
+        .select('*')
+        .eq('user_id', user.id);
       if (error) throw new Error(error.message);
       return data ?? [];
     },
@@ -29,6 +29,27 @@ export function useSaveSearch() {
       const { error } = await supabase
         .from('saved_searches')
         .insert({ user_id: user.id, criteria });
+      if (error) throw new Error(error.message);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['saved_searches'] });
+      },
+    },
+  );
+}
+
+export function useDeleteSavedSearch() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  return useMutation(
+    async (id: string) => {
+      if (!user) throw new Error('Must be signed in');
+      const { error } = await supabase
+        .from('saved_searches')
+        .delete()
+        .eq('id', id)
+        .eq('user_id', user.id);
       if (error) throw new Error(error.message);
     },
     {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, lazy, Suspense } from 'react';
+import { useLocation } from 'react-router-dom';
 import PropertyList from '../components/PropertyList';
 import PropertyFilter from '../components/PropertyFilter';
 import { useInfiniteProperties } from '../hooks/useProperties';
@@ -14,7 +15,10 @@ const PropertyMap = lazy(() => import('../components/PropertyMap'));
  * retrieve matching records from the database.
  */
 export default function HomePage() {
-  const [filters, setFilters] = useState<PropertyFilters>({});
+  const location = useLocation();
+  const [filters, setFilters] = useState<PropertyFilters>(
+    (location.state as { filters?: PropertyFilters } | null)?.filters || {},
+  );
   const {
     data,
     isLoading,
@@ -25,6 +29,11 @@ export default function HomePage() {
   } = useInfiniteProperties(filters);
   const properties = data?.pages.flat() ?? [];
   const loader = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const s = (location.state as { filters?: PropertyFilters } | null)?.filters;
+    if (s) setFilters(s);
+  }, [location.state]);
 
   useEffect(() => {
     if (!loader.current) return;

--- a/src/pages/SavedSearchesPage.tsx
+++ b/src/pages/SavedSearchesPage.tsx
@@ -1,0 +1,50 @@
+import { Link } from 'react-router-dom';
+import {
+  useSavedSearches,
+  useDeleteSavedSearch,
+} from '../hooks/useSavedSearches';
+import { useAuth } from '../hooks/useAuth';
+
+export default function SavedSearchesPage() {
+  const { user } = useAuth();
+  const { data: searches, isLoading, error } = useSavedSearches();
+  const deleteSearch = useDeleteSavedSearch();
+
+  if (!user) {
+    return <p className="p-4">Please sign in to manage saved searches.</p>;
+  }
+  if (isLoading) return <p className="p-4">Loading…</p>;
+  if (error)
+    return (
+      <p className="p-4 text-red-600">Error: {(error as Error).message}</p>
+    );
+
+  return (
+    <div className="max-w-5xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold mb-2">Saved searches</h1>
+      {searches && searches.length === 0 && <p>No saved searches.</p>}
+      {searches?.map((s) => (
+        <div key={s.id} className="border p-4 rounded flex justify-between">
+          <pre className="whitespace-pre-wrap text-sm flex-1">
+            {JSON.stringify(s.criteria, null, 2)}
+          </pre>
+          <div className="flex flex-col items-end gap-2 ml-4">
+            <Link
+              to="/"
+              state={{ filters: s.criteria }}
+              className="text-blue-600 underline text-sm"
+            >
+              Run search
+            </Link>
+            <button
+              onClick={() => deleteSearch.mutate(s.id)}
+              className="text-red-600 underline text-sm"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add bullet about saved searches to README
- route `/saved-searches` in App router and navigation link in Navbar
- allow HomePage to take filter criteria from location state
- support deleting saved searches and expose a new `SavedSearchesPage`

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d295372ac83238d50afc3fb23fb1f