### PR TITLE
Add Deno config for Supabase function

### DIFF
--- a/supabase/functions/nearby/tsconfig.json
+++ b/supabase/functions/nearby/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "dom.iterable", "deno.ns"],
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- add tsconfig to `supabase/functions/nearby` so TypeScript recognizes Deno modules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d32f38f90832395e5d589372c8b80