### PR TITLE
Polish property card UI and add theme tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project is a property listings portal inspired by popular real‑estate sites. It has been built using **React**, **TypeScript**, **Vite**, **Tailwind CSS**, **React Query** and **Supabase**. The goal of this portal is to provide a solid foundation for browsing, searching and managing property listings, while demonstrating how to integrate client‑side code with Supabase for authentication, storage and row‑level security.
 
+## Modern responsive UI
+
+The interface now uses a token based theme with a refined colour palette and typography. Property cards display price overlays and subtle hover animations while skeleton loaders keep layouts stable during data fetches.
+
 ## Features
 
 - **Browse and search properties** by location, price range, bedrooms, bathrooms, listing type and more.

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -55,14 +55,26 @@ export default function PropertyCard({ property }: Props) {
       to={`/properties/${property.id}`}
       onMouseEnter={prefetch}
       onFocus={prefetch}
-      className="bg-white rounded-lg shadow hover:shadow-md transition overflow-hidden flex flex-col"
+      className="relative bg-white rounded-lg shadow hover:shadow-lg transform hover:scale-[1.02] transition overflow-hidden flex flex-col"
     >
       {firstImage ? (
-        <img
-          src={firstImage.url}
-          alt={property.title}
-          className="h-48 w-full object-cover"
-        />
+        <div className="relative">
+          <img
+            src={firstImage.url}
+            alt={property.title}
+            className="h-48 w-full object-cover"
+          />
+          <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/70 to-transparent text-white p-2 text-sm">
+            <div className="font-semibold">
+              {property.listing_type === 'rent'
+                ? `£${property.price.toLocaleString()}/mo`
+                : `£${property.price.toLocaleString()}`}
+            </div>
+            <div>
+              {property.bedrooms} bd • {property.bathrooms} ba
+            </div>
+          </div>
+        </div>
       ) : (
         <div className="h-48 w-full bg-gray-200 flex items-center justify-center text-gray-400">
           No image
@@ -75,17 +87,7 @@ export default function PropertyCard({ property }: Props) {
         <p className="text-sm text-gray-600 mb-2 truncate">
           {property.city || property.address || '—'}
         </p>
-        <div className="mt-auto flex items-center justify-between">
-          <div>
-            <span className="text-xl font-bold text-blue-600">
-              {property.listing_type === 'rent'
-                ? `£${property.price.toLocaleString()}/mo`
-                : `£${property.price.toLocaleString()}`}
-            </span>
-            <span className="text-sm text-gray-500 ml-2">
-              {property.bedrooms} bd • {property.bathrooms} ba
-            </span>
-          </div>
+        <div className="mt-auto flex items-center justify-end">
           {user && (
             <div className="flex gap-2">
               <button

--- a/src/components/PropertyCardSkeleton.tsx
+++ b/src/components/PropertyCardSkeleton.tsx
@@ -1,0 +1,11 @@
+export default function PropertyCardSkeleton() {
+  return (
+    <div className="animate-pulse bg-white rounded-lg shadow overflow-hidden">
+      <div className="h-48 bg-gray-200" />
+      <div className="p-4 space-y-2">
+        <div className="h-4 bg-gray-200 rounded w-3/4" />
+        <div className="h-3 bg-gray-200 rounded w-1/2" />
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,5 +4,14 @@
 
 /* Additional global styles */
 body {
-  @apply bg-gray-50 text-gray-900;
+  @apply bg-gray-50 text-gray-900 font-body;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @apply font-heading;
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import { useLocation } from 'react-router-dom';
 import PropertyList from '../components/PropertyList';
 import PropertyFilter from '../components/PropertyFilter';
+import PropertyCardSkeleton from '../components/PropertyCardSkeleton';
 import { useInfiniteProperties } from '../hooks/useProperties';
 import type { PropertyFilters } from '../hooks/useProperties';
 import { useSaveSearch } from '../hooks/useSavedSearches';
@@ -61,7 +62,13 @@ export default function HomePage() {
             Save search
           </button>
         )}
-        {isLoading && <p className="p-4">Loading properties…</p>}
+        {isLoading && (
+          <div className="grid gap-6 p-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <PropertyCardSkeleton key={i} />
+            ))}
+          </div>
+        )}
         {error && <p className="p-4 text-red-600">Error: {error.message}</p>}
         {!isLoading && !error && properties && (
           <>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,20 @@
+export const colors = {
+  primary: '#2563eb',
+  secondary: '#64748b',
+  accent: '#d97706',
+  background: '#ffffff',
+  surface: '#f1f5f9',
+};
+
+export const fonts = {
+  body: ['Inter', 'sans-serif'],
+  heading: ['Poppins', 'sans-serif'],
+};
+
+export const spacing = {
+  xs: '0.25rem',
+  sm: '0.5rem',
+  md: '1rem',
+  lg: '1.5rem',
+  xl: '2rem',
+};

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,11 +1,17 @@
 /** @type {import('tailwindcss').Config} */
+const themeTokens = require('./src/styles/theme');
+
 module.exports = {
-  content: [
-    './index.html',
-    './src/**/*.{js,ts,jsx,tsx}',
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: themeTokens.colors,
+      fontFamily: {
+        body: themeTokens.fonts.body,
+        heading: themeTokens.fonts.heading,
+      },
+      spacing: themeTokens.spacing,
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add theme token definitions
- wire theme tokens into Tailwind
- style base fonts with new theme classes
- add price overlay and hover effects on property cards
- show skeleton property cards during initial load
- document the refreshed UI in the README

## Testing
- `npm run lint`
- `npm run format`
- `npm run test:e2e` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d3a0e6fd88323836d41c99c846712