### PR TITLE
Sanitize user supplied HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/ReviewList.tsx
+++ b/src/components/ReviewList.tsx
@@ -1,5 +1,6 @@
 import { useDeleteReview, useReviews } from '../hooks/useReviews';
 import { useAuth } from '../hooks/useAuth';
+import { sanitizeHtml } from '../lib/sanitizeHtml';
 
 type Props = { propertyId: string };
 
@@ -32,7 +33,9 @@ export default function ReviewList({ propertyId }: Props) {
               </button>
             )}
           </div>
-          {r.comment && <p className="text-gray-700 text-sm">{r.comment}</p>}
+          {r.comment && (
+            <p className="text-gray-700 text-sm">{sanitizeHtml(r.comment)}</p>
+          )}
         </li>
       ))}
     </ul>

--- a/src/lib/sanitizeHtml.ts
+++ b/src/lib/sanitizeHtml.ts
@@ -1,0 +1,20 @@
+interface DOMPurify {
+  sanitize: (html: string) => string;
+}
+
+export function sanitizeHtml(input: string): string {
+  const purify = (globalThis as unknown as { DOMPurify?: DOMPurify }).DOMPurify;
+  if (purify) {
+    return purify.sanitize(input);
+  }
+  const doc = new DOMParser().parseFromString(input, 'text/html');
+  doc.querySelectorAll('script,style').forEach((el) => el.remove());
+  doc.body.querySelectorAll('*').forEach((el) => {
+    for (const attr of Array.from(el.attributes)) {
+      if (/^on/i.test(attr.name) || attr.value.startsWith('javascript:')) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  });
+  return doc.body.innerHTML;
+}

--- a/src/pages/PropertyDetailPage.tsx
+++ b/src/pages/PropertyDetailPage.tsx
@@ -20,6 +20,7 @@ import {
   useAddPropertyToList,
 } from '../hooks/useFavoriteLists';
 import { useComparison } from '../hooks/useComparison';
+import { sanitizeHtml } from '../lib/sanitizeHtml';
 
 interface RouteParams {
   id: string;
@@ -258,7 +259,7 @@ export default function PropertyDetailPage() {
         <div>
           <h3 className="text-lg font-semibold mb-2">Description</h3>
           <p className="whitespace-pre-line text-gray-800">
-            {property.description}
+            {sanitizeHtml(property.description)}
           </p>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add DOMPurify via CDN
- create `sanitizeHtml` helper with DOMPurify fallback
- sanitize property descriptions and review comments before rendering

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browserType.launch executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d3db09fac8323a2a0a3f6498f87ec