### PR TITLE
Add CSP and sanitize script

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ property-portal/
 └── package.json         # Project configuration
 ```
 
+## Security
+
+When deploying this application, configure your hosting platform to redirect all
+HTTP traffic to HTTPS. Set headers like **Strict-Transport-Security**,
+**X-Content-Type-Options**, **X-Frame-Options**, **Referrer-Policy** and an
+appropriate **Content-Security-Policy** that only allows scripts from your own
+domain and your Supabase project.
+
 ## Testing
 
 Basic end‑to‑end smoke tests can be written using **Cypress** or **Playwright**. A simple example configuration is included under the `cypress/` and `playwright.config.js` folders. Running `npm run test:e2e` will execute those tests. Refer to the respective frameworks’ documentation for more details.

--- a/index.html
+++ b/index.html
@@ -3,11 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="upgrade-insecure-requests; script-src 'self' https://*.supabase.co"
+    />
     <title>Property Portal</title>
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/lib/sanitizeHtml.ts
+++ b/src/lib/sanitizeHtml.ts
@@ -1,12 +1,9 @@
-interface DOMPurify {
-  sanitize: (html: string) => string;
-}
-
+/**
+ * Basic HTML sanitizer used by the app.  It removes script and style tags
+ * along with any event handler attributes.  This implementation does not rely
+ * on DOMPurify so it can be bundled without external scripts.
+ */
 export function sanitizeHtml(input: string): string {
-  const purify = (globalThis as unknown as { DOMPurify?: DOMPurify }).DOMPurify;
-  if (purify) {
-    return purify.sanitize(input);
-  }
   const doc = new DOMParser().parseFromString(input, 'text/html');
   doc.querySelectorAll('script,style').forEach((el) => el.remove());
   doc.body.querySelectorAll('*').forEach((el) => {


### PR DESCRIPTION
## Summary
- enforce a basic Content Security Policy in `index.html`
- rely on built-in sanitizer instead of DOMPurify script
- document recommended security headers

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:e2e` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d504692c4832398357c86fb6f0522