### PR TITLE
feat: add mortgage calculator and area guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The interface now uses a token based theme with a refined colour palette and typ
 - **Row Level Security** policies are implemented to ensure users only read and modify the data they are authorised to access.
 - **Rate limiting** on login and enquiry submissions helps block abuse.
 - **Viewing appointments**: users can request a viewing and agents manage their schedule in a calendar view.
+- **Mortgage calculator**: estimate monthly repayments with adjustable deposit and term on property pages.
+- **Area guides**: dedicated pages show average prices, demographics and amenities for a city or postcode via a Supabase Edge Function.
 
 ## Getting started
 
@@ -68,14 +70,20 @@ For favourite lists and comparison support added in v7, run
 `supabase/update_v7.sql` after applying the earlier updates.
 To refresh derived data for existing rows, execute `supabase/update_v8.sql`
 after running the previous updates.
+Rate limiting and audit logging added in v9 and v10 require running
+`supabase/update_v9.sql` and `supabase/update_v10.sql` respectively.
+For the area guides feature introduced in v11, apply
+`supabase/update_v11.sql` after the earlier updates.
 
 5. **Deploy the Edge Function**
 
    The `supabase/functions/nearby` function caches queries to OpenStreetMap for
-   nearby schools and amenities.
+   nearby schools and amenities. The `supabase/functions/area-guide` function
+   fetches demographic and pricing data for area guide pages.
 
    ```bash
    supabase functions deploy nearby
+   supabase functions deploy area-guide
    ```
 
 6. **Start the development server**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import FavoritesPage from './pages/FavoritesPage';
 import FavoriteListsPage from './pages/FavoriteListsPage';
 import ComparePage from './pages/ComparePage';
 import SavedSearchesPage from './pages/SavedSearchesPage';
+import AreaGuidePage from './pages/AreaGuidePage';
 
 /**
  * Root component for the application.  It defines the top level layout
@@ -30,6 +31,7 @@ export default function App() {
           <Route path="/lists" element={<FavoriteListsPage />} />
           <Route path="/saved-searches" element={<SavedSearchesPage />} />
           <Route path="/compare" element={<ComparePage />} />
+          <Route path="/areas/:area" element={<AreaGuidePage />} />
         </Routes>
       </main>
     </div>

--- a/src/components/MortgageCalculator.tsx
+++ b/src/components/MortgageCalculator.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+
+interface MortgageCalculatorProps {
+  price: number;
+  initialDeposit?: number;
+  initialTerm?: number; // years
+}
+
+/**
+ * Simple mortgage calculator using a fixed 5% interest rate.  Users can adjust
+ * the deposit and term to estimate monthly repayments.
+ */
+export default function MortgageCalculator({
+  price,
+  initialDeposit,
+  initialTerm = 25,
+}: MortgageCalculatorProps) {
+  const [deposit, setDeposit] = useState(initialDeposit ?? Math.round(price * 0.1));
+  const [term, setTerm] = useState(initialTerm);
+
+  const principal = Math.max(price - deposit, 0);
+  const rate = 0.05 / 12; // fixed 5% APR
+  const payments = term * 12;
+  const monthly =
+    rate === 0
+      ? principal / payments
+      : (principal * rate * Math.pow(1 + rate, payments)) /
+        (Math.pow(1 + rate, payments) - 1);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+        <label className="text-sm" htmlFor="deposit">
+          Deposit (£)
+        </label>
+        <input
+          id="deposit"
+          type="number"
+          className="border rounded p-1 w-full sm:w-32"
+          value={deposit}
+          onChange={(e) => setDeposit(Number(e.target.value))}
+        />
+        <label className="text-sm" htmlFor="term">
+          Term (years)
+        </label>
+        <input
+          id="term"
+          type="number"
+          className="border rounded p-1 w-full sm:w-20"
+          value={term}
+          onChange={(e) => setTerm(Number(e.target.value))}
+        />
+      </div>
+      <p className="font-medium">
+        Monthly payment: £{Number.isFinite(monthly) ? monthly.toFixed(2) : '0.00'}
+      </p>
+    </div>
+  );
+}

--- a/src/hooks/useAreaGuide.ts
+++ b/src/hooks/useAreaGuide.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../lib/supabaseClient';
+
+export interface AreaGuide {
+  averagePrice: number | null;
+  demographics: Record<string, unknown>;
+  amenities: string[];
+}
+
+export function useAreaGuide(area: string | null) {
+  return useQuery({
+    queryKey: ['area-guide', area],
+    queryFn: async () => {
+      if (!area) return null;
+      const { data, error } = await supabase.functions.invoke('area-guide', {
+        body: { area },
+      });
+      if (error) throw new Error(error.message);
+      return data as AreaGuide;
+    },
+    enabled: !!area,
+  });
+}

--- a/src/pages/AreaGuidePage.tsx
+++ b/src/pages/AreaGuidePage.tsx
@@ -1,0 +1,44 @@
+import { useParams } from 'react-router-dom';
+import { useAreaGuide } from '../hooks/useAreaGuide';
+
+interface RouteParams {
+  area: string;
+}
+
+export default function AreaGuidePage() {
+  const { area } = useParams<RouteParams>();
+  const { data, isLoading, error } = useAreaGuide(area ?? null);
+
+  if (isLoading) {
+    return <p className="p-4">Loading area guide…</p>;
+  }
+  if (error || !data) {
+    return <p className="p-4 text-red-600">Failed to load area guide.</p>;
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
+      <h2 className="text-2xl font-bold">{area} area guide</h2>
+      <p className="text-lg">
+        Average price:{' '}
+        {data.averagePrice ? `£${data.averagePrice.toLocaleString()}` : 'N/A'}
+      </p>
+      <div>
+        <h3 className="font-semibold mt-4">Demographics</h3>
+        <pre className="bg-gray-100 p-2 rounded text-sm overflow-x-auto">
+          {JSON.stringify(data.demographics, null, 2)}
+        </pre>
+      </div>
+      {data.amenities.length > 0 && (
+        <div>
+          <h3 className="font-semibold mt-4">Amenities</h3>
+          <ul className="list-disc list-inside">
+            {data.amenities.map((a) => (
+              <li key={a}>{a}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/PropertyDetailPage.tsx
+++ b/src/pages/PropertyDetailPage.tsx
@@ -21,6 +21,7 @@ import {
 } from '../hooks/useFavoriteLists';
 import { useComparison } from '../hooks/useComparison';
 import { sanitizeHtml } from '../lib/sanitizeHtml';
+import MortgageCalculator from '../components/MortgageCalculator';
 
 interface RouteParams {
   id: string;
@@ -169,12 +170,21 @@ export default function PropertyDetailPage() {
         <h2 className="text-2xl font-bold">{property.title}</h2>
         <p className="text-gray-600">
           {property.address}, {property.city} {property.postcode}
+          {property.postcode && (
+            <Link
+              to={`/areas/${encodeURIComponent(property.postcode)}`}
+              className="text-blue-600 underline ml-2"
+            >
+              View area guide
+            </Link>
+          )}
         </p>
         <div className="text-xl font-semibold text-blue-600">
           {property.listing_type === 'rent'
             ? `£${property.price.toLocaleString()}/mo`
             : `£${property.price.toLocaleString()}`}
         </div>
+        <MortgageCalculator price={property.price} />
         <div className="text-gray-700">
           {property.bedrooms} bedrooms · {property.bathrooms} bathrooms ·{' '}
           {property.property_type}

--- a/supabase/functions/area-guide/index.ts
+++ b/supabase/functions/area-guide/index.ts
@@ -1,0 +1,88 @@
+import { serve } from '../deno_std_http_server.ts';
+import { createClient } from '../supabase_client.ts';
+
+interface RequestBody {
+  area: string;
+}
+
+serve(async (req: Request) => {
+  const { area } = (await req.json()) as RequestBody;
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  );
+
+  const { data: cached } = await supabase
+    .from('area_guides')
+    .select('data, updated_at')
+    .eq('area', area)
+    .maybeSingle();
+
+  if (
+    cached &&
+    new Date().getTime() - new Date(cached.updated_at as string).getTime() <
+      1000 * 60 * 60 * 24
+  ) {
+    return new Response(JSON.stringify(cached.data), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const postcodeRes = await fetch(
+    `https://api.postcodes.io/outcodes/${encodeURIComponent(area)}`,
+  );
+  const postcodeData = await postcodeRes.json();
+  const info = postcodeData?.result;
+  const lat = info?.latitude;
+  const lon = info?.longitude;
+  const onsCode = info?.codes?.laua as string | undefined;
+
+  let averagePrice: number | null = null;
+  let population: number | null = null;
+
+  if (onsCode) {
+    const priceRes = await fetch(
+      `https://api.beta.ons.gov.uk/v1/datasets/UKHPI/editions/time-series/versions/1/observations?time=latest&geography=${onsCode}`,
+    );
+    const priceData = await priceRes.json();
+    averagePrice = Number(priceData?.observations?.[0]?.value ?? null);
+
+    const popRes = await fetch(
+      `https://api.beta.ons.gov.uk/v1/datasets/MYE2/editions/time-series/versions/1/observations?time=latest&geography=${onsCode}&sex=0&age=ALL`,
+    );
+    const popData = await popRes.json();
+    population = Number(popData?.observations?.[0]?.value ?? null);
+  }
+
+  let amenities: string[] = [];
+  if (lat != null && lon != null) {
+    const query =
+      `[out:json];(node(around:1000,${lat},${lon})[amenity];);out;`;
+    const res = await fetch('https://overpass-api.de/api/interpreter', {
+      method: 'POST',
+      body: query,
+    });
+    const data = (await res.json()) as {
+      elements: { tags?: { name?: string } }[];
+    };
+    amenities = data.elements
+      .map((el) => el.tags?.name)
+      .filter((n): n is string => Boolean(n))
+      .slice(0, 10);
+  }
+
+  const result = {
+    averagePrice,
+    demographics: { population, region: info?.region },
+    amenities,
+  };
+
+  await supabase
+    .from('area_guides')
+    .upsert({ area, data: result, updated_at: new Date().toISOString() });
+
+  return new Response(JSON.stringify(result), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+});

--- a/supabase/functions/area-guide/tsconfig.json
+++ b/supabase/functions/area-guide/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "types": ["../deno.d.ts"],
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "strict": true
+  }
+}

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -211,6 +211,16 @@ create table if not exists public.rate_limits (
 );
 
 --
+-- Table: area_guides
+--
+-- Caches area guide data fetched from external APIs.
+create table if not exists public.area_guides (
+  area text primary key,
+  data jsonb not null,
+  updated_at timestamp with time zone default now()
+);
+
+--
 -- Table: audit_logs
 --
 -- Stores a history of changes to sensitive tables.
@@ -237,6 +247,7 @@ alter table public.saved_searches enable row level security;
 alter table public.reviews enable row level security;
 alter table public.listing_stats enable row level security;
 alter table public.appointments enable row level security;
+alter table public.area_guides enable row level security;
 
 --
 -- RLS Policies for profiles
@@ -471,6 +482,18 @@ with check (agent_id = auth.uid());
 
 create policy "Participants can delete appointments" on public.appointments
 for delete using (user_id = auth.uid() or agent_id = auth.uid());
+
+--
+-- RLS Policies for area_guides
+-- Public can view area guide information. Only the service role may modify it.
+create policy "Area guides are viewable by everyone" on public.area_guides
+  for select using (true);
+
+create policy "Service role can manage area guides" on public.area_guides
+  for insert with check (auth.role() = 'service_role');
+
+create policy "Service role can manage area guides" on public.area_guides
+  for update using (auth.role() = 'service_role');
 
 --
 -- Trigger to update properties.has_photo whenever images are added or removed.

--- a/supabase/update_v11.sql
+++ b/supabase/update_v11.sql
@@ -1,0 +1,19 @@
+-- Area guides cache
+-- Run this after update_v10.sql if upgrading an existing project
+
+create table if not exists public.area_guides (
+  area text primary key,
+  data jsonb not null,
+  updated_at timestamp with time zone default now()
+);
+
+alter table public.area_guides enable row level security;
+
+create policy "Area guides are viewable by everyone" on public.area_guides
+  for select using (true);
+
+create policy "Service role can manage area guides" on public.area_guides
+  for insert with check (auth.role() = 'service_role');
+
+create policy "Service role can manage area guides" on public.area_guides
+  for update using (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- add mortgage calculator to property detail page
- introduce area guides backed by Supabase Edge Function and database cache
- document new features and database update

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist; run npx playwright install)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e8b077efc8323b7456ae87c4e145b