### PR TITLE
fix: add CORS headers to nearby function

### DIFF
--- a/supabase/functions/nearby/index.ts
+++ b/supabase/functions/nearby/index.ts
@@ -1,7 +1,20 @@
 import { serve } from '../deno_std_http_server.ts';
 import { createClient } from '../supabase_client.ts';
 
+function corsHeaders(req: Request) {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers':
+      req.headers.get('access-control-request-headers') ??
+      'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  } as Record<string, string>;
+}
+
 serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders(req) });
+  }
   const { lat, lon } = (await req.json()) as { lat: number; lon: number };
 
   const supabase = createClient(
@@ -21,7 +34,7 @@ serve(async (req: Request) => {
 
   if (cached) {
     return new Response(JSON.stringify({ results: cached.results }), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...corsHeaders(req) },
     });
   }
 
@@ -46,6 +59,6 @@ serve(async (req: Request) => {
   });
 
   return new Response(JSON.stringify({ results }), {
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...corsHeaders(req) },
   });
 });


### PR DESCRIPTION
## Summary
- allow cross-origin calls to the `nearby` Edge Function

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_688e9a171fa88323bf839bb9cbdee0a6