### PR TITLE
fix: update appointment sample to new columns

### DIFF
--- a/supabase/update_v5.sql
+++ b/supabase/update_v5.sql
@@ -2,12 +2,20 @@
 -- Run this after update_v4.sql if upgrading an existing project
 
 -- Sample appointment data for testing the calendar
-insert into public.appointments(id, property_id, user_id, agent_id, timeslot, status)
-values (
+insert into public.appointments (
+  id,
+  property_id,
+  user_id,
+  agent_id,
+  starts_at,
+  ends_at,
+  status
+) values (
   uuid_generate_v4(),
   '11111111-2222-4333-8444-555555555555',
   '00000000-0000-4000-8000-000000000002',
   '00000000-0000-4000-8000-000000000001',
   now() + interval '14 days',
+  (now() + interval '14 days') + interval '1 hour',
   'pending'
 );


### PR DESCRIPTION
## Summary
- update calendar view sample data to use `starts_at` and `ends_at` instead of removed `timeslot`

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at chromium_headless_shell; please run “npx playwright install”)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e9c2e219c832388a3176e050c22da