### PR TITLE
Handle legacy appointment timeslot

### DIFF
--- a/supabase/update_v12.sql
+++ b/supabase/update_v12.sql
@@ -6,19 +6,29 @@ alter table public.appointments
   add column if not exists starts_at timestamp with time zone,
   add column if not exists ends_at timestamp with time zone;
 
--- Migrate existing timeslot values into the new columns
-update public.appointments
-  set starts_at = timeslot,
-      ends_at = timeslot + interval '1 hour'
-  where starts_at is null;
+-- Migrate existing timeslot values into the new columns if the legacy column exists
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'appointments'
+      and column_name = 'timeslot'
+  ) then
+    update public.appointments
+      set starts_at = timeslot,
+          ends_at = timeslot + interval '1 hour'
+      where starts_at is null;
+
+    alter table public.appointments
+      drop column timeslot;
+  end if;
+end $$;
 
 alter table public.appointments
   alter column starts_at set not null,
   alter column ends_at set not null;
-
--- Remove legacy column
-alter table public.appointments
-  drop column if exists timeslot;
 
 -- Update status values and constraints
 update public.appointments set status = 'approved' where status = 'confirmed';


### PR DESCRIPTION
## Summary
- guard v12 SQL migration against missing `timeslot` column by conditionally migrating and dropping it
- query explicit appointment fields in React hook to avoid references to removed `timeslot`

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browser download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e9e867bf48323a4948450b1aa9ee3