### PR TITLE
Use supabase client for enquiries

### DIFF
--- a/src/hooks/useProperty.tsx
+++ b/src/hooks/useProperty.tsx
@@ -62,19 +62,16 @@ export function useSendMessage() {
       receiverId: string;
       content: string;
     }) => {
-      const res = await fetch('/functions/v1/enquiry', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+      const { error } = await supabase.functions.invoke('enquiry', {
+        body: {
           propertyId,
           senderId,
           receiverId,
           content,
-        }),
+        },
       });
-      const result = await res.json();
-      if (!res.ok) {
-        throw new Error(result.error ?? 'Failed to send message');
+      if (error) {
+        throw new Error(error.message ?? 'Failed to send message');
       }
     },
   );


### PR DESCRIPTION
## Summary
- switch send-message hook to use Supabase functions client

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f3af004988323a2adf6227fd4466a