### PR TITLE
feat: handle empty enquiry responses

### DIFF
--- a/src/hooks/useProperty.tsx
+++ b/src/hooks/useProperty.tsx
@@ -62,16 +62,27 @@ export function useSendMessage() {
       receiverId: string;
       content: string;
     }) => {
-      const { error } = await supabase.functions.invoke('enquiry', {
+      const { data, error } = await supabase.functions.invoke('enquiry', {
         body: {
           propertyId,
           senderId,
           receiverId,
           content,
         },
+        noResolveJson: true,
       });
       if (error) {
         throw new Error(error.message ?? 'Failed to send message');
+      }
+      const res = data as Response;
+      let result: { error?: string } | null = null;
+      try {
+        result = await res.json();
+      } catch {
+        // ignore JSON parse errors from empty responses
+      }
+      if (!res.ok) {
+        throw new Error(result?.error ?? 'Failed to send message');
       }
     },
   );


### PR DESCRIPTION
## Summary
- avoid JSON parsing errors in `useSendMessage` when enquiry responses are empty

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install` *(fails: Download failed, server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f3edb85248323898c9be96272b5e4