### PR TITLE
Handle CORS preflight for nearby function

### DIFF
--- a/supabase/functions/nearby/index.ts
+++ b/supabase/functions/nearby/index.ts
@@ -1,19 +1,18 @@
 import { serve } from '../deno_std_http_server.ts';
 import { createClient } from '../supabase_client.ts';
 
-function corsHeaders(req: Request) {
+function corsHeaders() {
   return {
     'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
     'Access-Control-Allow-Headers':
-      req.headers.get('access-control-request-headers') ??
-      'authorization, x-client-info, apikey, content-type',
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Content-Type, Authorization, apikey, x-client-info',
   } as Record<string, string>;
 }
 
 serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders(req) });
+    return new Response('ok', { headers: corsHeaders() });
   }
   const { lat, lon } = (await req.json()) as { lat: number; lon: number };
 
@@ -34,7 +33,7 @@ serve(async (req: Request) => {
 
   if (cached) {
     return new Response(JSON.stringify({ results: cached.results }), {
-      headers: { 'Content-Type': 'application/json', ...corsHeaders(req) },
+      headers: { 'Content-Type': 'application/json', ...corsHeaders() },
     });
   }
 
@@ -59,6 +58,6 @@ serve(async (req: Request) => {
   });
 
   return new Response(JSON.stringify({ results }), {
-    headers: { 'Content-Type': 'application/json', ...corsHeaders(req) },
+    headers: { 'Content-Type': 'application/json', ...corsHeaders() },
   });
 });


### PR DESCRIPTION
## Summary
- ensure `nearby` Edge Function responds to OPTIONS preflight with permissive CORS headers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7678e0e88323b782c174df402c18