### PR TITLE
Add CORS headers to Supabase functions

### DIFF
--- a/supabase/functions/enquiry/index.ts
+++ b/supabase/functions/enquiry/index.ts
@@ -1,15 +1,12 @@
 import { serve } from '../deno_std_http_server.ts';
 import { createClient } from '../supabase_client.ts';
 
-function corsHeaders(req: Request) {
-  return {
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers':
-      req.headers.get('access-control-request-headers') ??
-      'authorization, x-client-info, apikey, content-type',
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  } as Record<string, string>;
-}
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Content-Type, Authorization, apikey, x-client-info',
+} as Record<string, string>;
 
 async function incrementAttempt(
   supabase: ReturnType<typeof createClient>,
@@ -41,7 +38,7 @@ async function incrementAttempt(
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders(req) });
+    return new Response('ok', { headers: corsHeaders });
   }
   const { propertyId, senderId, receiverId, content } = (await req.json()) as {
     propertyId: string;
@@ -69,7 +66,7 @@ serve(async (req) => {
   if (rate.blocked) {
     return new Response(JSON.stringify({ error: 'Too many enquiries' }), {
       status: 429,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders(req) },
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
     });
   }
 
@@ -82,10 +79,10 @@ serve(async (req) => {
   if (error) {
     return new Response(JSON.stringify({ error: error.message }), {
       status: 400,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders(req) },
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
     });
   }
   return new Response(JSON.stringify({ success: true }), {
-    headers: { 'Content-Type': 'application/json', ...corsHeaders(req) },
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
   });
 });

--- a/supabase/functions/nearby/index.ts
+++ b/supabase/functions/nearby/index.ts
@@ -1,18 +1,16 @@
 import { serve } from '../deno_std_http_server.ts';
 import { createClient } from '../supabase_client.ts';
 
-function corsHeaders() {
-  return {
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-    'Access-Control-Allow-Headers':
-      'Content-Type, Authorization, apikey, x-client-info',
-  } as Record<string, string>;
-}
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Content-Type, Authorization, apikey, x-client-info',
+} as Record<string, string>;
 
 serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders() });
+    return new Response('ok', { headers: corsHeaders });
   }
   const { lat, lon } = (await req.json()) as { lat: number; lon: number };
 
@@ -33,7 +31,7 @@ serve(async (req: Request) => {
 
   if (cached) {
     return new Response(JSON.stringify({ results: cached.results }), {
-      headers: { 'Content-Type': 'application/json', ...corsHeaders() },
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
     });
   }
 
@@ -58,6 +56,6 @@ serve(async (req: Request) => {
   });
 
   return new Response(JSON.stringify({ results }), {
-    headers: { 'Content-Type': 'application/json', ...corsHeaders() },
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
   });
 });


### PR DESCRIPTION
## Summary
- ensure `nearby` function returns standard CORS headers for preflight and JSON responses
- ensure `enquiry` function returns standard CORS headers for preflight and JSON responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7a0a45d08323b778a7203f2e4678